### PR TITLE
Added install into alternatives

### DIFF
--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -34,6 +34,14 @@
   tags:
     - installation
 
+- name: install into alternatives
+  shell:
+    "alternatives --install /usr/bin/java java {{ oracle_java_home }}/jre/bin/java 200000"
+  when: not oracle_java_task_rpm_check|skipped
+  sudo: yes
+  tags:
+    - installation
+
 - name: set Java version as default
   shell: "alternatives --set java {{ oracle_java_home }}/jre/bin/java"
   when: oracle_java_set_as_default


### PR DESCRIPTION
While trying to set an alternatives, I am getting an error stating:

TASK: [ansiblebit.oracle-java | set Java version as default] ******************
failed: [52.20.85.226] => {"changed": true, "cmd": "alternatives --set java /usr/java/jdk1.7.0_79/jre/bin/java", "delta": "0:00:00.002550", "end": "2015-08-20 21:13:05.581852", "rc": 2, "start": "2015-08-20 21:13:05.579302", "warnings": []}
stderr: /usr/java/jdk1.7.0_79/jre/bin/java has not been configured as an alternative for java

FATAL: all hosts have already failed -- aborting

I basically just added it to alternatives before trying to set it and it worked as usual. Feel free to discuss, not sure how this worked prior.
