### PR TITLE
switch from \" to '"' in shell lines

### DIFF
--- a/tasks/check_environment.yml
+++ b/tasks/check_environment.yml
@@ -39,7 +39,7 @@
 # determine which Java version is installed
 
 - name: if Java is installed, check version
-  shell: java -version 2>&1 | head -n 1 | awk '{ print $3 }' | awk -F \" '{ print $2 }'
+  shell: java -version 2>&1 | head -n 1 | awk '{ print $3 }' | awk -F '"' '{ print $2 }'
   when: oracle_java_installed
   register: oracle_java_task_version
   changed_when: False

--- a/tests/tasks/main.yml
+++ b/tests/tasks/main.yml
@@ -25,7 +25,7 @@
   when: oracle_java_version_installed != expected_java_version
 
 - name: register result_java_version with host installed Java version
-  shell: java -version 2>&1 | head -n 1 | awk '{ print $3 }' | awk -F \" '{ print $2 }'
+  shell: java -version 2>&1 | head -n 1 | awk '{ print $3 }' | awk -F '"' '{ print $2 }'
   register: result_java_version
   changed_when: no
 


### PR DESCRIPTION
Otherwise the parser in ansible-git will bug out with

Traceback (most recent call last):
  File "command", line 2285, in <module>
    main()
  File "command", line 226, in main
    rc, out, err = module.run_command(args, executable=executable, use_unsafe_shell=shell)
  File "command", line 1928, in run_command
    to_clean_args = shlex.split(b_args)
  File "/usr/lib/python2.7/shlex.py", line 279, in split
    return list(lex)
  File "/usr/lib/python2.7/shlex.py", line 269, in next
    token = self.get_token()
  File "/usr/lib/python2.7/shlex.py", line 96, in get_token
    raw = self.read_token()
  File "/usr/lib/python2.7/shlex.py", line 172, in read_token
    raise ValueError, "No closing quotation"
ValueError: No closing quotation

Thanks to @mgedmin in #ansible for the fix
