### PR TITLE
 debian-apt: cache_valid_time without update_cache

### DIFF
--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -14,6 +14,7 @@
     name="oracle-java{{ oracle_java_version }}-installer"
     state={{ oracle_java_state }}
     cache_valid_time={{ oracle_java_cache_valid_time }}
+    update_cache=yes
   register: oracle_java_task_apt_install
   sudo: yes
 


### PR DESCRIPTION
Reading ansible doc `cache_valid_time` used without `update_cache` will
not update apt cache.
- http://docs.ansible.com/ansible/apt_module.html

```
If update_cache is specified and the last run is less or equal than cache_valid_time seconds ago, the update_cache gets skipped.
```

Doc example :

```
# Only run "update_cache=yes" if the last one is more than 3600 seconds ago
- apt: update_cache=yes cache_valid_time=3600
```

This commit add `update_cache` flag to ensure apt is updated to setup java.

I didn't see `how to contrib` part in your readme. I did the pull request on develop branch is ok for you or I need to do in on master ?

Regards,
