### PR TITLE
fix apt-cache update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 |:-:|:-:|:-:|:-:|
 | Debian | Debian  | Jessie    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Debian  | Wheezy    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
-| Debian | Ubuntu  | Precise   | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#)  |
+| Debian | Ubuntu  | Precise   | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Trusty    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Vivid     | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | RedHat | CentOS  | 6.4       | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
@@ -48,8 +48,8 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | oracle_java_set_as_default | no | make the newly installed Java the default runtime environment. |
 | oracle_java_state   | latest | the package state (see Ansible apt module for more information). |
 | oracle_java_version | 8 | the Oracle JDK version to be installed. |
-| oracle_java_version_update | 45 | the Oracle JDK version update. |
-| oracle_java_version_build | 14 | the Oracle JDK version update build number. |
+| oracle_java_version_update | 74 | the Oracle JDK version update. |
+| oracle_java_version_build | 02 | the Oracle JDK version update build number. |
 | oracle_java_version_string | 1.{{ oracle_java_version }}.0_u{{ oracle_java_version_update }} | the Java version string to verify installation against. |
 | oracle_java_os_supported variable | - | role internal variable to check if a OS family is supported or not. | 
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | Family | Distribution | Version | Test Status |
 |:-:|:-:|:-:|:-:|
 | Debian | Debian  | Jessie    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
-| Debian | Debian  | Wheezy    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Precise   | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Trusty    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Vivid     | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
+| Debian | Ubuntu  | Wily      | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | RedHat | CentOS  | 6.4       | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | RedHat | CentOS  | 6.6       | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | RedHat | Centos  | 7         | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | Debian | Ubuntu  | Trusty    | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Vivid     | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | Debian | Ubuntu  | Wily      | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
-| RedHat | CentOS  | 6.4       | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
-| RedHat | CentOS  | 6.6       | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 | RedHat | Centos  | 7         | [![x86_64](http://img.shields.io/badge/x86_64-passed-006400.svg?style=flat)](#) |
 
 ## Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,6 @@ oracle_java_dir_source: '/usr/local/src'
 oracle_java_set_as_default: no
 
 oracle_java_version: 8
-oracle_java_version_update: 60
-oracle_java_version_build: 27
+oracle_java_version_update: 74
+oracle_java_version_build: '02'
 oracle_java_version_string: "1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,15 +20,6 @@ galaxy_info:
       versions:
         - jessie
         - wheezy
-    - name: MacOSX
-      versions:
-        - 10.10.2
-        - 10.10.1
-        - 10.9.5
-        - 10.9.4
-        - 10.9.3
-        - 10.9.2
-        - 10.9.1
     - name: RedHat
       versions:
         - all
@@ -40,8 +31,9 @@ galaxy_info:
         - vivid
         - trusty
         - precise
-  categories:
+  galaxy_tags:
     - development
+    - java
     - system
 dependencies:
   - role: ansiblebit.launchpad-ppa-webupd8

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -14,6 +14,7 @@
     name="oracle-java{{ oracle_java_version }}-installer"
     state={{ oracle_java_state }}
     cache_valid_time={{ oracle_java_cache_valid_time }}
+    update_cache=yes
   register: oracle_java_task_apt_install
   sudo: yes
 

--- a/tests/boxes.yml
+++ b/tests/boxes.yml
@@ -59,7 +59,7 @@ vagrant:
         cpus: 1
 
   wheezy64.vagrant.dev:
-    enabled: true
+    enabled: false
     box: debian/wheezy64
     network:
       name: private_network
@@ -194,3 +194,28 @@ vagrant:
       virtualbox:
         memory: 1024
         cpus: 1
+
+  wily32.vagrant.dev:
+    enabled: false
+    box: ubuntu/wily32
+    network:
+      name: private_network
+      ip: 192.168.124.7
+
+    provider:
+      virtualbox:
+        memory: 1024
+        cpus: 1
+
+  wily64.vagrant.dev:
+    enabled: true
+    box: ubuntu/vivid64
+    network:
+      name: private_network
+      ip: 192.168.124.8
+
+    provider:
+      virtualbox:
+        memory: 1024
+        cpus: 1
+

--- a/tests/boxes.yml
+++ b/tests/boxes.yml
@@ -8,7 +8,7 @@ vagrant:
   # CentOS
 
   centos64-64.vagrant.dev:
-    enabled: true
+    enabled: false
     box: hansode/centos-6.4-x86_64
     network:
       name: private_network
@@ -20,7 +20,7 @@ vagrant:
         cpus: 1
 
   centos66-64.vagrant.dev:
-    enabled: true
+    enabled: false
     box: hansode/centos-6.6-x86_64
     network:
       name: private_network
@@ -33,7 +33,7 @@ vagrant:
 
   centos7-64.vagrant.dev:
     enabled: true
-    box: relativkreativ/centos-7-minimal
+    box: centos/7
     network:
       name: private_network
       ip: 192.168.121.3

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,8 +7,8 @@
 
   vars:
     test_java_version: 8
-    test_java_version_update: 60
-    test_java_version_build: 27
+    test_java_version_update: 72
+    test_java_version_build: 15
 
   roles:
     - { role: oracle-java,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27}-{ansible193}
+    {py27}-{ansible2002,ansible194}
 
 skipsdist = True
 
@@ -8,8 +8,9 @@ skipsdist = True
 [testenv]
 changedir = tests
 deps =
-    travis: ansible==1.9.3
-    ansible193: ansible==1.9.3
+    travis: ansible==1.9.4
+    ansible2002: ansible==2.0.0.2
+    ansible194: ansible==1.9.4
 
 passenv = ANSIBLE_ASK_SUDO_PASS HOME
 


### PR DESCRIPTION
- removed testing for ansible 1.9.3
- added testing for ansible 1.9.4 and 2.0.0.2
- updated the Java version used for testing so Debian tests pass
- fixed galaxy errors and warnings for issue #8
- no longer test for wheezy
- no longer test for centos 6.4 and 6.6
- updated centos 7 image
