### PR TITLE
Support recent Fedoras' dnf package manager

### DIFF
--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -15,9 +15,7 @@
     - installation
 
 - name: install RPM
-  yum:
-    name="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
-    state=present
+  action: "{{ ansible_pkg_mgr }} name={{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }} state=present"
   when: not oracle_java_task_rpm_download|skipped
   sudo: yes
   tags:


### PR DESCRIPTION
Dnf replaced Yum (keeping the same cli interface though) for some time on
Fedora.

Likewise, the ansible RPM provided in Fedora (23+) doesn't include the "yum"
Ansible module, so we must use the "dnf" module there (which, thanksfully,
has the same arguments as the "yum" module).

Let's use
  action: "{{ ansible_pkg_mgr }} [...]"
on RPM based distributions, to maintain compatibility with both yum and dnf.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansiblebit/oracle-java/23)

<!-- Reviewable:end -->
