### PR TITLE
issue 34 and 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | oracle_java_set_as_default | yes | make the newly installed Java the default runtime environment. |
 | oracle_java_state   | latest | the package state (see Ansible apt module for more information). |
 | oracle_java_version | 8 | the Oracle JDK version to be installed. |
-| oracle_java_version_update | 102 | the Oracle JDK version update. |
-| oracle_java_version_build | 14 | the Oracle JDK version update build number. |
+| oracle_java_version_update | 112 | the Oracle JDK version update. |
+| oracle_java_version_build | 15 | the Oracle JDK version update build number. |
 | oracle_java_version_string | 1.{{ oracle_java_version }}.0_u{{ oracle_java_version_update }} | the Java version string to verify installation against. |
 | oracle_java_os_supported | - | role internal variable to check if a OS family is supported or not. | 
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | oracle_java_set_as_default | yes | make the newly installed Java the default runtime environment. |
 | oracle_java_state   | latest | the package state (see Ansible apt module for more information). |
 | oracle_java_version | 8 | the Oracle JDK version to be installed. |
-| oracle_java_version_update | 121 | the Oracle JDK version update. |
-| oracle_java_version_build | 13 | the Oracle JDK version update build number. |
+| oracle_java_version_update | 102 | the Oracle JDK version update. |
+| oracle_java_version_build | 14 | the Oracle JDK version update build number. |
 | oracle_java_version_string | 1.{{ oracle_java_version }}.0_u{{ oracle_java_version_update }} | the Java version string to verify installation against. |
 | oracle_java_os_supported | - | role internal variable to check if a OS family is supported or not. | 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | oracle_java_home | /usr/java/jdk1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }} | the location of the Java home directory. |
 | oracle_java_rpm_filename | jdk-{{ oracle_java_version }}u{{ oracle_java_version_update }}-linux-x64.rpm | the filename of the RPM. |
 | oracle_java_rpm_url | http://download.oracle.com/otn-pub/java/jdk/{{ oracle_java_version }}u{{ oracle_java_version_update }}-b{{ oracle_java_version_build }}/{{ oracle_java_rpm_filename }} | the URL where the RPM can be downloaded from. |
+| oracle_java_rpm_validate_certs | yes | flag to indicate if you want SSL certificate validation. |
 
 
 ## Playbooks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,6 @@ oracle_java_dir_source: '/usr/local/src'
 oracle_java_set_as_default: yes
 
 oracle_java_version: 8
-oracle_java_version_update: 121
-oracle_java_version_build: 13
+oracle_java_version_update: 102
+oracle_java_version_build: 14
 oracle_java_version_string: "1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,6 @@ oracle_java_dir_source: '/usr/local/src'
 oracle_java_set_as_default: yes
 
 oracle_java_version: 8
-oracle_java_version_update: 102
-oracle_java_version_build: 14
+oracle_java_version_update: 112
+oracle_java_version_build: 15
 oracle_java_version_string: "1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -10,3 +10,4 @@ oracle_java_os_supported: yes
 
 oracle_java_rpm_filename: "jdk-{{ oracle_java_version }}u{{ oracle_java_version_update }}-linux-x64.rpm"
 oracle_java_rpm_url: "http://download.oracle.com/otn-pub/java/jdk/{{ oracle_java_version }}u{{ oracle_java_version_update }}-b{{ oracle_java_version_build }}/{{ oracle_java_rpm_filename }}"
+oracle_java_rpm_validate_certs: yes

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -6,21 +6,18 @@
 
 - name: download Java RPM
   get_url:
-    headers='Cookie:oraclelicense=accept-securebackup-cookie'
-    dest="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
+    headers='Cookie:gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie'    dest="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
     url="{{ oracle_java_rpm_url }}"
     validate_certs="{{ oracle_java_rpm_validate_certs }}"
   register: oracle_java_task_rpm_download
   become: yes
-  tags:
-    - installation
+  tags: [ installation ]
 
 - name: install RPM
   action: "{{ ansible_pkg_mgr }} name={{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }} state=present"
   when: not oracle_java_task_rpm_download|skipped
   become: yes
-  tags:
-    - installation
+  tags: [ installation ]
 
 - name: set Java version as default
   alternatives:

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -6,9 +6,10 @@
 
 - name: download Java RPM
   get_url:
-    headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-    dest: "{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
-    url: "{{ oracle_java_rpm_url }}"
+    headers='Cookie:oraclelicense=accept-securebackup-cookie'
+    dest="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
+    url="{{ oracle_java_rpm_url }}"
+    validate_certs="{{ oracle_java_rpm_validate_certs }}"
   register: oracle_java_task_rpm_download
   become: yes
   tags:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,12 +14,11 @@
 - name: tests play
   hosts: all
   gather_facts: yes
-
   vars:
     debug: yes
     test_java_version: 8
-    test_java_version_update: 121
-    test_java_version_build: 13
+    test_java_version_update: 102
+    test_java_version_build: 14
 
   roles:
     - role: oracle-java
@@ -27,6 +26,7 @@
       oracle_java_version_update: "{{ test_java_version_update }}"
       oracle_java_version_build: "{{ test_java_version_build }}"
       oracle_java_set_as_default: yes
+      oracle_java_rpm_validate_certs: no
 
     - role: tests
       expected_java_version: "1.{{ test_java_version }}.0_{{ test_java_version_update }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -17,8 +17,8 @@
   vars:
     debug: yes
     test_java_version: 8
-    test_java_version_update: 102
-    test_java_version_build: 14
+    test_java_version_update: 112
+    test_java_version_build: 15
 
   roles:
     - role: oracle-java


### PR DESCRIPTION
- fix #34 
  - set `oracle_java_version_update` to `112` and `oracle_java_version_build` to `15`
  - using `121` update fails the download
- fix #35 
  - added new variable `oracle_java_rpm_validate_certs `
