### PR TITLE
include_vars changed

### DIFF
--- a/defaults/darwin-macosx.yml
+++ b/defaults/darwin-macosx.yml
@@ -8,4 +8,4 @@ oracle_java_dir_source: "{{ ansible_env.HOME }}/Downloads"
 oracle_java_dmg_filename: ""
 oracle_java_dmg_url: "/{{ oracle_java_dmg_filename }}"
 
-oracle_java_os_supported: yes
+oracle_java_os_supported: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,17 +9,27 @@
 
 ## include OS family specific variables
 
+- debug:
+    msg="{{ item }}"
+  with_items:
+    - "vars/{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}.yml"
+    - "vars/{{ ansible_os_family | lower }}.yml"
+
 - name: include OS family/distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "../defaults/{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "../defaults/{{ ansible_distribution | lower }}.yml"
-    - "../defaults/{{ ansible_os_family | lower }}.yml"
+    - "defaults/{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}.yml"
+    - "defaults/{{ ansible_os_family | lower }}.yml"
   tags: installation
 
 - include: debug.yml
   when: debug | default(false)
   tags: debug
+
+- name: check if operating system is suported
+  fail:
+    msg: "The operating system ({{ ansible_os_family }}) of the target machine ({{ inventory_hostname }}) is not currently supported."
+  when: oracle_java_os_supported is not defined or not oracle_java_os_supported
 
 ## include OS family specific task file
 
@@ -34,8 +44,3 @@
 - name: if redhat, include family specific task file
   include: "redhat/main.yml"
   when: ansible_os_family | lower == 'redhat'
-
-- name: check if operating system is suported
-  fail:
-    msg: "The operating system ({{ ansible_os_family }}) of the target machine ({{ inventory_hostname }}) is not currently supported."
-  when: oracle_java_os_supported is not defined or not oracle_java_os_supported

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,12 +9,6 @@
 
 ## include OS family specific variables
 
-- debug:
-    msg="{{ item }}"
-  with_items:
-    - "vars/{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}.yml"
-    - "vars/{{ ansible_os_family | lower }}.yml"
-
 - name: include OS family/distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
- do not use relative path to load OS/distribution specific variables: #37 
- test OS/distribution support before include task files
- OSX is not supported
