### PR TITLE
Remove unnecessary curly brackets from *when: statements

### DIFF
--- a/tasks/check_environment.yml
+++ b/tasks/check_environment.yml
@@ -9,7 +9,7 @@
 - name: determine if Java is already installed
   shell: which java
   register: oracle_java_task_installed
-  changed_when: "{{ oracle_java_task_installed.rc != 0 }}"
+  changed_when: oracle_java_task_installed.rc != 0
   failed_when: no
 # oracle_java_installed.rc == 0 : installed
 # oracle_java_installed.rc == 1 : not installed
@@ -32,7 +32,7 @@
 
 - debug:
     var="{{ item }}"
-  when: "{{ item }} is defined and debug | default(false)"
+  when: item is defined and debug | default(false)
   with_items:
     - oracle_java_installed
     - oracle_java_task_installed

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -18,7 +18,7 @@
     changed_when: licence_not_accepted.rc != 0
     become: yes
 
-  when: "{{ ansible_distribution == 'Ubuntu' }}"
+  when: ansible_distribution == 'Ubuntu'
 
 - block:
   - name: debian | ensure the webupd8 launchpad apt repository key is present
@@ -38,11 +38,11 @@
       - deb-src
     become: yes
 
-  when: "{{ ansible_distribution == 'Debian' }}"
+  when: ansible_distribution == 'Debian'
 
 - name: debian | set license as accepted
   debconf: name='oracle-java{{ oracle_java_version }}-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
-  when: "{{ licence_not_accepted|changed or licence_not_accepted|skipped }}"
+  when: licence_not_accepted|changed or licence_not_accepted|skipped
   become: yes
 
 - name: debian | ensure Java is installed

--- a/tasks/debug.yml
+++ b/tasks/debug.yml
@@ -6,7 +6,7 @@
 
 - debug:
     var="{{ item }}"
-  when: "{{ item }} is defined"
+  when: item is defined
   with_items:
     - oracle_java_cache_valid_time
     - oracle_java_home


### PR DESCRIPTION
The braces are unnecessary. See http://docs.ansible.com/ansible/playbooks_conditionals.html#the-when-statement

Their presence caused a warning:
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}.