### PR TITLE
Implemented rpm search on oracle site, fixes #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 | oracle_java_set_as_default | yes | make the newly installed Java the default runtime environment. |
 | oracle_java_state   | latest | the package state (see Ansible apt module for more information). |
 | oracle_java_version | 8 | the Oracle JDK version to be installed. |
-| oracle_java_version_update | 112 | the Oracle JDK version update. |
-| oracle_java_version_build | 15 | the Oracle JDK version update build number. |
 | oracle_java_version_string | 1.{{ oracle_java_version }}.0_u{{ oracle_java_version_update }} | the Java version string to verify installation against. |
 | oracle_java_os_supported | - | role internal variable to check if a OS family is supported or not. | 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ oracle_java_dir_source: '/usr/local/src'
 oracle_java_set_as_default: yes
 
 oracle_java_version: 8
-oracle_java_version_update: 112
-oracle_java_version_build: 15
 oracle_java_version_string: "1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"
+oracle_java_ansible_arch_mappings:
+  x86_64: x64
+  i386: i586

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -7,7 +7,4 @@
 oracle_java_home: "/usr/java/jdk1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"
 
 oracle_java_os_supported: yes
-
-oracle_java_rpm_filename: "jdk-{{ oracle_java_version }}u{{ oracle_java_version_update }}-linux-x64.rpm"
-oracle_java_rpm_url: "http://download.oracle.com/otn-pub/java/jdk/{{ oracle_java_version }}u{{ oracle_java_version_update }}-b{{ oracle_java_version_build }}/{{ oracle_java_rpm_filename }}"
 oracle_java_rpm_validate_certs: yes

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -4,6 +4,49 @@
 # Task file to install Oracle Java Development Kit in a system with a Redhat based Linux distribution.
 #
 
+- name: get latest JDK download page
+  uri:
+    url: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+    return_content: yes
+  register: result
+
+- name: determine latest java download page and version
+  set_fact: latest_java_page_and_version="{{ (result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/downloads/jdk(\d+)-downloads.*?.html).*', 'http://www.oracle.com/\1\n\2')).split('\n') }}"
+
+- name: define download page URL based on latest version
+  set_fact: download_page_url="{{ latest_java_page_and_version[0] }}"
+  when: "{{ latest_java_page_and_version[1]|version_compare(oracle_java_version,'=') }}"
+  
+- block:
+  
+  - name: get lastest JDK rpm url
+    uri: url="{{ result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/archive-.*?.html).*','http://www.oracle.com/\1') }}"
+         return_content=yes
+    register: result
+    
+  - name: define download page URL for "{{ oracle_java_version }}"
+    set_fact: download_page_url="{{ result.content|regex_search('href=\"[^\"]+\">Java SE\s+' + (oracle_java_version|string) + '\s?<')|regex_replace('.*href=\"([^\"]+)\".*','http://www.oracle.com/\1') }}"
+  
+  when: "{{ latest_java_page_and_version[1]|version_compare(oracle_java_version,'!=') and oracle_java_version }}"
+
+- name: show download page URL
+  debug: msg="{{ download_page_url }}"
+
+- name: get lastest JDK rpm url
+  uri: url="{{ download_page_url }}"
+       return_content=yes
+  register: result
+
+- name: set oracle_java_rpm_url
+  set_fact: oracle_java_rpm_url="{{ result.content|regex_search('https?://download.oracle.com/.*?/jdk-\w+-linux-' + oracle_java_ansible_arch_mappings[ansible_architecture] + '.rpm') }}"
+
+- name: set some variables
+  set_fact: oracle_java_rpm_filename="{{ oracle_java_rpm_url | basename }}"
+            oracle_java_version="{{ oracle_java_rpm_url | basename|regex_replace('jdk-(\d+)u(\d+)-linux.*','\1') }}"
+            oracle_java_version_update="{{ oracle_java_rpm_url | basename|regex_replace('jdk-(\d+)u(\d+)-linux.*','\2') }}"
+
+- debug: msg="Downloading java {{ oracle_java_version }}u{{ oracle_java_version_update }} to {{ oracle_java_rpm_filename }} from {{ oracle_java_rpm_url }}"
+
 - name: download Java RPM
   get_url:
     headers='Cookie:gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie'    dest="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"


### PR DESCRIPTION
Tested with java 8, however rpm download fails for java 7, didn't have time to investigate.

Didn't implement `latest` for `oracle_java_version` because this value goes to `oracle_java_home` even if later redefined to a number. Probably `oracle_java_home` should be moved from `defaults` to `set_fact`.
