### PR TITLE
Resolve file path with `{{ role_path }}`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,8 +12,8 @@
 - name: include OS family/distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "defaults/{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}.yml"
-    - "defaults/{{ ansible_os_family | lower }}.yml"
+    - "{{ role_path }}/defaults/{{ ansible_os_family | lower }}-{{ ansible_distribution | lower }}.yml"
+    - "{{ role_path }}/defaults/{{ ansible_os_family | lower }}.yml"
   tags: installation
 
 - include: debug.yml


### PR DESCRIPTION
I was getting errors with this playbook when executing "include OS family/distribution specific variables." Even though my `ansible_os_family` is `RedHat`, `with_first_found` was finding no results. (I am running Centos 7, but I confirmed the `RedHat` value in the ansible facts with `ansible all -m setup`.)

When I prepended the `defaults/...` relative path with `{{ role_path }}`, this playbook ran successfully.