### PR TITLE
Ensure dirmngr is installed.

### DIFF
--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -3,6 +3,11 @@
 #
 # Task file to install Oracle Java Development Kit in a system with a Debian based Linux distribution.
 #
+- name: install dirmngr
+  apt:
+    name="dirmngr"
+    state="present"
+  become: yes
 
 - name: debian | ubuntu | add java ppa repo
   apt_repository:

--- a/tests/plugins/callback/idempotence.py
+++ b/tests/plugins/callback/idempotence.py
@@ -2,10 +2,9 @@
 
 from __future__ import (absolute_import, print_function)
 
-import sys
 import os
+import sys
 
-from ansible import constants as C
 from ansible.constants import mk_boolean
 
 try:


### PR DESCRIPTION
On a minimal install of Debian that doesn't have the 'dirmngr' package installed, this role fails.