### PR TITLE
retry RPM download if it fails

### DIFF
--- a/defaults/linuxmint.yml
+++ b/defaults/linuxmint.yml
@@ -1,0 +1,1 @@
+debian.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,7 @@ oracle_java_version_string: "1.{{ oracle_java_version }}.0_{{ oracle_java_versio
 oracle_java_ansible_arch_mappings:
   x86_64: x64
   i386: i586
+
+# codename hash to convert mint to ubuntu releases
+oracle_java_ppa_mint:
+  sonya: xenial

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,4 @@ oracle_java_ansible_arch_mappings:
 # codename hash to convert mint to ubuntu releases
 oracle_java_ppa_mint:
   sonya: xenial
+  sylvia: xenial

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -33,6 +33,9 @@ galaxy_info:
         - vivid
         - trusty
         - precise
+    - name: Linuxmint
+      versions:
+        - sonya
   galaxy_tags:
     - development
     - java

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -36,6 +36,7 @@ galaxy_info:
     - name: Linuxmint
       versions:
         - sonya
+        - sylvia
   galaxy_tags:
     - development
     - java

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -4,12 +4,13 @@
 # Task file to install Oracle Java Development Kit in a system with a Debian based Linux distribution.
 #
 
-- name: debian | ubuntu | add java ppa repo
+- name: debian | (ubuntu or mint) | add java ppa repo
   apt_repository:
     repo=ppa:webupd8team/java
     state=present
+    codename='{{ oracle_java_ppa_mint[ansible_lsb.codename]|default(ansible_lsb.codename) }}'
   become: yes
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Linuxmint'
 
 - block:
   - name: debian | ensure the webupd8 launchpad apt repository key is present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: if debian, include family specific task file
   include: "debian/main.yml"
-  when: ansible_os_family | lower == 'debian'
+  when: ansible_os_family | lower == 'debian' or ansible_os_family | lower == 'linuxmint'
 
 - name: if redhat, include family specific task file
   include: "redhat/main.yml"

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -54,6 +54,7 @@
     validate_certs="{{ oracle_java_rpm_validate_certs }}"
     timeout={{ oracle_java_download_timeout }}
   register: oracle_java_task_rpm_download
+  until: oracle_java_task_rpm_download|succeeded 
   become: yes
   tags: [ installation ]
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -19,7 +19,7 @@
     test_java_version: 8
     test_java_version_update: 112
     test_java_version_build: 15
-    test_latest_java_version_update: 144
+    test_latest_java_version_update: 151
     test_latest_java_version_build: 13
 
   roles:


### PR DESCRIPTION
this particular task is prone to occasional errors since it downloads a large file over the internet. would be nice to have it retry a few times automatically, especially for playbooks running across a group of servers.