### PR TITLE
retry RPM download if it fails

### DIFF
--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -54,6 +54,7 @@
     validate_certs="{{ oracle_java_rpm_validate_certs }}"
     timeout={{ oracle_java_download_timeout }}
   register: oracle_java_task_rpm_download
+  until: oracle_java_task_rpm_download|succeeded 
   become: yes
   tags: [ installation ]
 


### PR DESCRIPTION
this particular task is prone to occasional errors since it downloads a large file over the internet. would be nice to have it retry a few times automatically, especially for playbooks running across a group of servers.