### PR TITLE
include_vars overrides user set variables and should be conditional instead

### DIFF
--- a/defaults/darwin-macosx.yml
+++ b/defaults/darwin-macosx.yml
@@ -4,8 +4,8 @@
 # Default variables for OSX-based Darwin distributions.
 #
 
-oracle_java_dir_source: "{{ ansible_env.HOME }}/Downloads"
-oracle_java_dmg_filename: ""
-oracle_java_dmg_url: "/{{ oracle_java_dmg_filename }}"
+__oracle_java_dir_source: "{{ ansible_env.HOME }}/Downloads"
+__oracle_java_dmg_filename: ""
+__oracle_java_dmg_url: "/{{ oracle_java_dmg_filename }}"
 
-oracle_java_os_supported: no
+__oracle_java_os_supported: no

--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -4,10 +4,10 @@
 # Default variables for Debian-based Linux distributions.
 #
 
-oracle_java_cache_valid_time: 3600
+__oracle_java_cache_valid_time: 3600
 
-oracle_java_home: "/usr/lib/jvm/java-{{ oracle_java_version }}-oracle"
+__oracle_java_home: "/usr/lib/jvm/java-{{ oracle_java_version }}-oracle"
 
-oracle_java_os_supported: yes
+__oracle_java_os_supported: yes
 
-oracle_java_state: latest
+__oracle_java_state: latest

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -4,9 +4,9 @@
 # Default variables for Redhat-based Linux distributions.
 #
 
-oracle_java_home: "/usr/java/jdk-{{ oracle_java_version }}"
+__oracle_java_home: "/usr/java/jdk1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"
 
-oracle_java_os_supported: yes
-oracle_java_rpm_validate_certs: yes
+__oracle_java_os_supported: yes
+__oracle_java_rpm_validate_certs: yes
 
-oracle_java_download_timeout: 10
+__oracle_java_download_timeout: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,9 @@
     - "{{ role_path }}/defaults/{{ ansible_os_family | lower }}.yml"
   tags: installation
 
+- include: vars.yml
+  tags: installation
+
 - include: debug.yml
   when: debug | default(false)
   tags: debug

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -11,44 +11,38 @@
   register: result
 
 - name: determine latest java download page and version
-  set_fact: latest_java_page_and_version="{{ (result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/downloads/jdk(9)-downloads.*?.html).*', 'http://www.oracle.com/\1\n\2')).split('\n') }}"
-
-- name: show latest java page and version page URL
-  debug: msg="{{ latest_java_page_and_version }}"
+  set_fact: latest_java_page_and_version="{{ (result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/downloads/jdk(\d+)-downloads.*?.html).*', 'http://www.oracle.com/\1\n\2')).split('\n') }}"
 
 - name: define download page URL based on latest version
   set_fact: download_page_url="{{ latest_java_page_and_version[0] }}"
-  when: latest_java_page_and_version[1] | version_compare(oracle_java_version,'=')
-
+  when: "{{ latest_java_page_and_version[1]|version_compare(oracle_java_version,'=') }}"
+  
 - block:
-
-  - name: get latest JDK rpm url
+  
+  - name: get lastest JDK rpm url
     uri: url="{{ result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/archive-.*?.html).*','http://www.oracle.com/\1') }}"
          return_content=yes
     register: result
-
+    
   - name: define download page URL for "{{ oracle_java_version }}"
     set_fact: download_page_url="{{ result.content|regex_search('href=\"[^\"]+\">Java SE\s+' + (oracle_java_version|string) + '\s?<')|regex_replace('.*href=\"([^\"]+)\".*','http://www.oracle.com/\1') }}"
-
-  when: latest_java_page_and_version[1] | version_compare(oracle_java_version,'!=') and oracle_java_version
+  
+  when: "{{ latest_java_page_and_version[1]|version_compare(oracle_java_version,'!=') and oracle_java_version }}"
 
 - name: show download page URL
   debug: msg="{{ download_page_url }}"
 
-- name: get latest JDK rpm url
+- name: get lastest JDK rpm url
   uri: url="{{ download_page_url }}"
        return_content=yes
   register: result
 
 - name: set oracle_java_rpm_url
-  set_fact: oracle_java_rpm_url="{{ result.content|regex_search('https?://download.oracle.com/.*?/jdk-.*(-|_)linux-' + oracle_java_ansible_arch_mappings[ansible_architecture] + '(_bin)?.rpm') }}"
-
-- name: show rpm URL
-  debug: msg="{{ oracle_java_rpm_url }}"
+  set_fact: oracle_java_rpm_url="{{ result.content|regex_search('https?://download.oracle.com/.*?/jdk-\w+-linux-' + oracle_java_ansible_arch_mappings[ansible_architecture] + '.rpm') }}"
 
 - name: set some variables
   set_fact: oracle_java_rpm_filename="{{ oracle_java_rpm_url | basename }}"
-            oracle_java_version="{{ oracle_java_rpm_url | basename|regex_replace('jdk-(.*)(-|_)linux.*','\1') }}"
+            oracle_java_version="{{ oracle_java_rpm_url | basename|regex_replace('jdk-(\d+)u(\d+)-linux.*','\1') }}"
             oracle_java_version_update="{{ oracle_java_rpm_url | basename|regex_replace('jdk-(\d+)u(\d+)-linux.*','\2') }}"
 
 - debug: msg="Downloading java {{ oracle_java_version }}u{{ oracle_java_version_update }} to {{ oracle_java_rpm_filename }} from {{ oracle_java_rpm_url }}"
@@ -60,7 +54,6 @@
     validate_certs="{{ oracle_java_rpm_validate_certs }}"
     timeout={{ oracle_java_download_timeout }}
   register: oracle_java_task_rpm_download
-  until: oracle_java_task_rpm_download|succeeded 
   become: yes
   tags: [ installation ]
 
@@ -70,17 +63,14 @@
   become: yes
   tags: [ installation ]
 
-- name: show oracle version
-  debug: msg="{{ oracle_java_version }}"
-
 - name: set Java version as default
   alternatives:
     name="{{ item.exe }}"
     link="/usr/bin/{{ item.exe }}"
     path="{{ item.path }}/{{ item.exe }}"
   with_items:
-    - { path: "{{ oracle_java_home }}/bin", exe: 'java' }
-    - { path: "{{ oracle_java_home }}/bin", exe: 'keytool' }
+    - { path: "{{ oracle_java_home }}/jre/bin", exe: 'java' }
+    - { path: "{{ oracle_java_home }}/jre/bin", exe: 'keytool' }
     - { path: "{{ oracle_java_home }}/bin", exe: 'javac' }
     - { path: "{{ oracle_java_home }}/bin", exe: 'javadoc' }
   become: yes

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,0 +1,55 @@
+---
+# Variable configuration.
+- name: Define oracle_java_os_supported.
+  set_fact:
+    oracle_java_os_supported: "{{ __oracle_java_os_supported }}"
+  when: oracle_java_os_supported is not defined
+
+- name: Define oracle_java_cache_valid_time.
+  set_fact:
+    oracle_java_cache_valid_time: "{{ __oracle_java_cache_valid_time }}"
+  when: 
+    - ansible_os_family == "Debian" 
+    - oracle_java_cache_valid_time is not defined
+
+- name: Define oracle_java_home.
+  set_fact:
+    oracle_java_home: "{{ __oracle_java_home }}"
+  when:
+    - (ansible_os_family == "RedHat" or ansible_os_family == "Debian") 
+    - oracle_java_home is not defined
+
+- name: Define oracle_java_state.
+  set_fact:
+    oracle_java_state: "{{ __oracle_java_state }}"
+  when: 
+    - ansible_os_family == "Debian" 
+    - oracle_java_state is not defined
+
+- name: Define oracle_java_rpm_validate_certs.
+  set_fact:
+    oracle_java_rpm_validate_certs: "{{ __oracle_java_rpm_validate_certs }}"
+  when: 
+    - ansible_os_family == "RedHat"
+    - oracle_java_rpm_validate_certs is not defined
+
+- name: Define oracle_java_download_timeout.
+  set_fact:
+    oracle_java_download_timeout: "{{ __oracle_java_download_timeout }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - oracle_java_download_timeout is not defined
+
+- name: Define oracle_java_dmg_filename.
+  set_fact:
+    oracle_java_dmg_filename: "{{ __oracle_java_dmg_filename }}"
+  when: 
+    - ansible_os_family == "Darwin"
+    - oracle_java_dmg_filename is not defined
+
+- name: Define oracle_java_dmg_url.
+  set_fact:
+    oracle_java_dmg_url: "{{ __oracle_java_dmg_url }}"
+  when:
+    - ansible_os_family == "Darwin"
+    - oracle_java_dmg_url is not defined


### PR DESCRIPTION
Currently it's not possible to set oracle_java_home since the include_vars will override that setting. By using set_fact and renaming the os specific variables the problem is solved