### PR TITLE
include_vars overrides user set variables and should be conditional instead

### DIFF
--- a/defaults/darwin-macosx.yml
+++ b/defaults/darwin-macosx.yml
@@ -4,8 +4,8 @@
 # Default variables for OSX-based Darwin distributions.
 #
 
-oracle_java_dir_source: "{{ ansible_env.HOME }}/Downloads"
-oracle_java_dmg_filename: ""
-oracle_java_dmg_url: "/{{ oracle_java_dmg_filename }}"
+__oracle_java_dir_source: "{{ ansible_env.HOME }}/Downloads"
+__oracle_java_dmg_filename: ""
+__oracle_java_dmg_url: "/{{ oracle_java_dmg_filename }}"
 
-oracle_java_os_supported: no
+__oracle_java_os_supported: no

--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -4,10 +4,10 @@
 # Default variables for Debian-based Linux distributions.
 #
 
-oracle_java_cache_valid_time: 3600
+__oracle_java_cache_valid_time: 3600
 
-oracle_java_home: "/usr/lib/jvm/java-{{ oracle_java_version }}-oracle"
+__oracle_java_home: "/usr/lib/jvm/java-{{ oracle_java_version }}-oracle"
 
-oracle_java_os_supported: yes
+__oracle_java_os_supported: yes
 
-oracle_java_state: latest
+__oracle_java_state: latest

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -4,9 +4,9 @@
 # Default variables for Redhat-based Linux distributions.
 #
 
-oracle_java_home: "/usr/java/jdk-{{ oracle_java_version }}"
+__oracle_java_home: "/usr/java/jdk-{{ oracle_java_version }}"
 
-oracle_java_os_supported: yes
-oracle_java_rpm_validate_certs: yes
+__oracle_java_os_supported: yes
+__oracle_java_rpm_validate_certs: yes
 
-oracle_java_download_timeout: 10
+__oracle_java_download_timeout: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,9 @@
     - "{{ role_path }}/defaults/{{ ansible_os_family | lower }}.yml"
   tags: installation
 
+- include: vars.yml
+  tags: installation
+
 - include: debug.yml
   when: debug | default(false)
   tags: debug

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,0 +1,55 @@
+---
+# Variable configuration.
+- name: Define oracle_java_os_supported.
+  set_fact:
+    oracle_java_os_supported: "{{ __oracle_java_os_supported }}"
+  when: oracle_java_os_supported is not defined
+
+- name: Define oracle_java_cache_valid_time.
+  set_fact:
+    oracle_java_cache_valid_time: "{{ __oracle_java_cache_valid_time }}"
+  when: 
+    - ansible_os_family == "Debian" 
+    - oracle_java_cache_valid_time is not defined
+
+- name: Define oracle_java_home.
+  set_fact:
+    oracle_java_home: "{{ __oracle_java_home }}"
+  when:
+    - (ansible_os_family == "RedHat" or ansible_os_family == "Debian") 
+    - oracle_java_home is not defined
+
+- name: Define oracle_java_state.
+  set_fact:
+    oracle_java_state: "{{ __oracle_java_state }}"
+  when: 
+    - ansible_os_family == "Debian" 
+    - oracle_java_state is not defined
+
+- name: Define oracle_java_rpm_validate_certs.
+  set_fact:
+    oracle_java_rpm_validate_certs: "{{ __oracle_java_rpm_validate_certs }}"
+  when: 
+    - ansible_os_family == "RedHat"
+    - oracle_java_rpm_validate_certs is not defined
+
+- name: Define oracle_java_download_timeout.
+  set_fact:
+    oracle_java_download_timeout: "{{ __oracle_java_download_timeout }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - oracle_java_download_timeout is not defined
+
+- name: Define oracle_java_dmg_filename.
+  set_fact:
+    oracle_java_dmg_filename: "{{ __oracle_java_dmg_filename }}"
+  when: 
+    - ansible_os_family == "Darwin"
+    - oracle_java_dmg_filename is not defined
+
+- name: Define oracle_java_dmg_url.
+  set_fact:
+    oracle_java_dmg_url: "{{ __oracle_java_dmg_url }}"
+  when:
+    - ansible_os_family == "Darwin"
+    - oracle_java_dmg_url is not defined


### PR DESCRIPTION
Currently it's not possible to set oracle_java_home since the include_vars will override that setting. By using set_fact and renaming the os specific variables the problem is solved