### PR TITLE
Oracle removed Java 9 from downloads

### DIFF
--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -11,7 +11,7 @@
   register: result
 
 - name: determine latest java download page and version
-  set_fact: latest_java_page_and_version="{{ (result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/downloads/jdk(9)-downloads.*?.html).*', 'http://www.oracle.com/\1\n\2')).split('\n') }}"
+  set_fact: latest_java_page_and_version="{{ (result.content.replace('\n','')|regex_replace('.*(/technetwork/java/javase/downloads/jdk(\d{1,2})-downloads.*?.html).*', 'http://www.oracle.com/\1\n\2')).split('\n') }}"
 
 - name: show latest java page and version page URL
   debug: msg="{{ latest_java_page_and_version }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -19,7 +19,7 @@
     test_java_version: 8
     test_java_version_update: 112
     test_java_version_build: 15
-    test_latest_java_version_update: 161
+    test_latest_java_version_update: 181
     test_latest_java_version_build: 13
 
   roles:


### PR DESCRIPTION
So let's use a 1-2 digit as a pattern instead of a hardcoded
number