### PR TITLE
6.22.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ See `debian | ubuntu | Java 8` example in the _Playbooks_ section.
 - **oracle_java_deb_package**: name of debian package.
 - **oracle_java_debconf_package_default**: name of debconf package to set default.
 - **oracle_java_home**: the location of the Java home directory.
+- **oracle_java_license_version**: which Oracle license version you will be accepting.
 - **oracle_java_state**:** the package state (see Ansible apt module for more information).
 
 ### Redhat-only
@@ -122,6 +123,7 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
         oracle_java_deb_package: 'oracle-java8-installer'
         oracle_java_debconf_package_default: 'oracle-java8-set-default'
         oracle_java_home: "/usr/lib/jvm/java-8-oracle"
+        oracle_java_license_version: "shared/accepted-oracle-license-v1-1"
         oracle_java_set_as_default: no
         oracle_java_state: latest
 
@@ -140,6 +142,7 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
         oracle_java_deb_package: 'oracle-java10-installer'
         oracle_java_debconf_package_default: 'oracle-java10-set-default'
         oracle_java_home: "/usr/lib/jvm/java-10-oracle"
+        oracle_java_license_version: "shared/accepted-oracle-license-v1-1"
         oracle_java_set_as_default: no
         oracle_java_state: latest
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
         oracle_java_set_as_default: no
         oracle_java_state: latest
 
-# redhat | centos 7 | Java 10
+# redhat | centos 7 | Java 11
 - hosts: servers
   roles:
       - role: ansiblebit.oracle-java

--- a/README.md
+++ b/README.md
@@ -153,15 +153,16 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
 - hosts: servers
   roles:
       - role: ansiblebit.oracle-java
+        oracle_java_use_defaults: no
         oracle_java_dir_source: '/usr/local/src'
         oracle_java_download_timeout: 60  
-        oracle_java_rpm_filename: 'jdk-8u181-linux-x64.rpm'
+        oracle_java_rpm_filename: 'jdk-8u191-linux-x64.rpm'
         oracle_java_home: '/usr/java/default'
         oracle_java_os_supported: yes
-        oracle_java_rpm_url: 'http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.rpm'
+        oracle_java_rpm_url: 'http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.rpm'
         oracle_java_rpm_validate_certs: yes
         oracle_java_set_as_default: no
-        oracle_java_version_string: 1.8.0_181
+        oracle_java_version_string: 1.8.0_191
 ```
 
 Use `--skip-tags=debug` if you want to suppress debug information.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 ## Role Variables
 
 - **debug**: flag to make role more verbose.
-- **oracle_java_os_supported**: role internal variable to check if a OS family is supported or not.
+- **oracle_java_os_supported**: internal variable to check if a OS family is supported or not.
 - **oracle_java_set_as_default**: flag to indicate if this play should set Java as default (default: `yes`).
 - **oracle_java_use_defaults**: flag to indicate you want to use defaults set in the `defaults` directory (default: `yes`).
   **WARNING**. setting this to `no` will require the user to pass all of the distribution variables.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ DISCLAIMER: usage of any version of this role implies you have accepted the
 ## Role Variables
 
 - **debug**: flag to make role more verbose.
-- **oracle_java_os_supported**: internal variable to check if a OS family is supported or not.
 - **oracle_java_set_as_default**: flag to indicate if this play should set Java as default (default: `yes`).
 - **oracle_java_use_defaults**: flag to indicate you want to use defaults set in the `defaults` directory (default: `yes`).
   **WARNING**. setting this to `no` will require the user to pass all of the distribution variables.
@@ -102,7 +101,7 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
   roles:
       - role: ansiblebit.oracle-java
 
-# debian | Java 10
+# debian | Java 11
 - hosts: servers
   roles:
       - role: ansiblebit.oracle-java
@@ -126,7 +125,7 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
         oracle_java_set_as_default: no
         oracle_java_state: latest
 
-# debian | ubuntu | Java 10
+# debian | ubuntu | Java 11
 - hosts: servers
   roles:
       - role: ansiblebit.oracle-java

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ See `redhat | centos 7 | Java 8` example in the _Playbooks_ section.
         oracle_java_use_defaults: no
         oracle_java_apt_repository: "ppa:webupd8team/java"
         oracle_java_cache_valid_time: 3600
-        oracle_java_deb_package: 'oracle-java10-installer'
-        oracle_java_debconf_package_default: 'oracle-java10-set-default'
-        oracle_java_home: "/usr/lib/jvm/java-10-oracle"
+        oracle_java_deb_package: 'oracle-java8-installer'
+        oracle_java_debconf_package_default: 'oracle-java8-set-default'
+        oracle_java_home: "/usr/lib/jvm/java-8-oracle"
         oracle_java_set_as_default: no
         oracle_java_state: latest
 

--- a/defaults/darwin-macosx.yml
+++ b/defaults/darwin-macosx.yml
@@ -6,6 +6,4 @@
 
 oracle_java_dir_source: "{{ ansible_env.HOME }}/Downloads"
 oracle_java_dmg_filename: ""
-oracle_java_os_supported: no
-
 oracle_java_dmg_url: "/{{ oracle_java_dmg_filename }}"

--- a/defaults/debian-ubuntu.yml
+++ b/defaults/debian-ubuntu.yml
@@ -9,5 +9,5 @@ oracle_java_cache_valid_time: 3600
 oracle_java_deb_package: 'oracle-java11-installer'
 oracle_java_debconf_package_default: 'oracle-java11-set-default'
 oracle_java_home: "/usr/lib/jvm/java-11-oracle"
-oracle_java_license_version: 'shared/accepted-oracle-license-v1-1'
+oracle_java_license_version: 'shared/accepted-oracle-license-v1-2'
 oracle_java_state: latest

--- a/defaults/debian-ubuntu.yml
+++ b/defaults/debian-ubuntu.yml
@@ -4,9 +4,10 @@
 # Default variables for Ubuntu Linux distributions.
 #
 
-oracle_java_apt_repository: "ppa:linuxuprising/java"
+oracle_java_apt_repository: 'ppa:linuxuprising/java'
 oracle_java_cache_valid_time: 3600
 oracle_java_deb_package: 'oracle-java11-installer'
 oracle_java_debconf_package_default: 'oracle-java11-set-default'
 oracle_java_home: "/usr/lib/jvm/java-11-oracle"
+oracle_java_license_version: 'shared/accepted-oracle-license-v1-1'
 oracle_java_state: latest

--- a/defaults/debian-ubuntu.yml
+++ b/defaults/debian-ubuntu.yml
@@ -6,7 +6,7 @@
 
 oracle_java_apt_repository: "ppa:linuxuprising/java"
 oracle_java_cache_valid_time: 3600
-oracle_java_deb_package: 'oracle-java10-installer'
-oracle_java_debconf_package_default: 'oracle-java10-set-default'
-oracle_java_home: "/usr/lib/jvm/java-10-oracle"
+oracle_java_deb_package: 'oracle-java11-installer'
+oracle_java_debconf_package_default: 'oracle-java11-set-default'
+oracle_java_home: "/usr/lib/jvm/java-11-oracle"
 oracle_java_state: latest

--- a/defaults/debian-ubuntu.yml
+++ b/defaults/debian-ubuntu.yml
@@ -9,5 +9,4 @@ oracle_java_cache_valid_time: 3600
 oracle_java_deb_package: 'oracle-java10-installer'
 oracle_java_debconf_package_default: 'oracle-java10-set-default'
 oracle_java_home: "/usr/lib/jvm/java-10-oracle"
-oracle_java_os_supported: yes
 oracle_java_state: latest

--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -7,7 +7,7 @@
 oracle_java_apt_repository: 'deb http://ppa.launchpad.net/linuxuprising/java/ubuntu bionic main'
 oracle_java_apt_repository_key: 'EA8CACC073C3DB2A'
 oracle_java_cache_valid_time: 3600
-oracle_java_deb_package: 'oracle-java10-installer'
-oracle_java_debconf_package_default: 'oracle-java10-set-default'
-oracle_java_home: "/usr/lib/jvm/java-10-oracle"
+oracle_java_deb_package: 'oracle-java11-installer'
+oracle_java_debconf_package_default: 'oracle-java11-set-default'
+oracle_java_home: "/usr/lib/jvm/java-11-oracle"
 oracle_java_state: latest

--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -10,5 +10,4 @@ oracle_java_cache_valid_time: 3600
 oracle_java_deb_package: 'oracle-java10-installer'
 oracle_java_debconf_package_default: 'oracle-java10-set-default'
 oracle_java_home: "/usr/lib/jvm/java-10-oracle"
-oracle_java_os_supported: yes
 oracle_java_state: latest

--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -10,4 +10,5 @@ oracle_java_cache_valid_time: 3600
 oracle_java_deb_package: 'oracle-java11-installer'
 oracle_java_debconf_package_default: 'oracle-java11-set-default'
 oracle_java_home: "/usr/lib/jvm/java-11-oracle"
+oracle_java_license_version: 'shared/accepted-oracle-license-v1-1'
 oracle_java_state: latest

--- a/defaults/debian.yml
+++ b/defaults/debian.yml
@@ -10,5 +10,5 @@ oracle_java_cache_valid_time: 3600
 oracle_java_deb_package: 'oracle-java11-installer'
 oracle_java_debconf_package_default: 'oracle-java11-set-default'
 oracle_java_home: "/usr/lib/jvm/java-11-oracle"
-oracle_java_license_version: 'shared/accepted-oracle-license-v1-1'
+oracle_java_license_version: 'shared/accepted-oracle-license-v1-2'
 oracle_java_state: latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,5 @@
 # defaults file
 #
 
-oracle_java_os_supported: yes
 oracle_java_set_as_default: yes
 oracle_java_use_defaults: yes

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -6,10 +6,9 @@
 
 oracle_java_dir_source: '/usr/local/src'
 oracle_java_download_timeout: 60
-oracle_java_rpm_filename: 'jdk-10.0.2_linux-x64_bin.rpm'
+oracle_java_rpm_filename: 'jdk-11.0.1_linux-x64_bin.rpm'
 oracle_java_home: '/usr/java/default'
-oracle_java_os_supported: yes
-oracle_java_rpm_url: 'http://download.oracle.com/otn-pub/java/jdk/10.0.2+13/19aef61b38124481863b1413dce1855f/jdk-10.0.2_linux-x64_bin.rpm'
+oracle_java_rpm_url: 'http://download.oracle.com/otn-pub/java/jdk/11.0.1+13/90cf5d8f270a4347a95050320eef3fb7/jdk-11.0.1_linux-x64_bin.rpm'
 oracle_java_rpm_validate_certs: yes
-oracle_java_version: 10
-oracle_java_version_string: 10.0.2
+oracle_java_version: 11
+oracle_java_version_string: 11.0.1

--- a/tasks/check_environment.yml
+++ b/tasks/check_environment.yml
@@ -38,3 +38,5 @@
     - oracle_java_task_installed
     - oracle_java_task_version
     - oracle_java_version_installed
+  when: debug | default(false)
+  tags: [ debug ]

--- a/tasks/check_environment.yml
+++ b/tasks/check_environment.yml
@@ -38,5 +38,4 @@
     - oracle_java_task_installed
     - oracle_java_task_version
     - oracle_java_version_installed
-  when: debug | default(false)
   tags: [ debug ]

--- a/tasks/debug.yml
+++ b/tasks/debug.yml
@@ -11,7 +11,6 @@
     - oracle_java_cache_valid_time
     - oracle_java_home
     - oracle_java_installed
-    - oracle_java_os_supported
     - oracle_java_apt_repository
     - oracle_java_apt_repository_key
     - oracle_java_set_as_default

--- a/tasks/debug.yml
+++ b/tasks/debug.yml
@@ -13,6 +13,7 @@
     - oracle_java_installed
     - oracle_java_apt_repository
     - oracle_java_apt_repository_key
+    - oracle_java_license_version
     - oracle_java_set_as_default
     - oracle_java_state
     - oracle_java_version_installed

--- a/tasks/installation/debian/main.yml
+++ b/tasks/installation/debian/main.yml
@@ -22,9 +22,10 @@
 - name: debian | set license as accepted
   debconf:
     name="{{ oracle_java_deb_package }}"
-    question='shared/accepted-oracle-license-v1-1'
+    question="{{ oracle_java_license_version }}"
     value='true'
     vtype='select'
+  become: yes
   become: yes
 
 - name: debian | ensure Java is installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - include: debug.yml
   when: debug | default(false)
-  tags: debug
+  tags: [ debug ]
 
 ## include OS family/distribution specific task file
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,11 +23,6 @@
   when: debug | default(false)
   tags: debug
 
-- name: check if operating system is suported
-  fail:
-    msg: "The operating system ({{ ansible_os_family }}) of the target machine ({{ inventory_hostname }}) is not currently supported."
-  when: oracle_java_os_supported is not defined or not oracle_java_os_supported
-
 ## include OS family/distribution specific task file
 
 - name: include OS family/distribution specific task file

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -25,7 +25,7 @@
   gather_facts: yes
   vars:
     debug: yes
-    test_expected_java_version: '10.0.2'
+    test_expected_java_version: '11.0.1'
 
   roles:
     - role: oracle-java

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -29,7 +29,6 @@
 
   roles:
     - role: oracle-java
-      when: ansible_os_family | lower == 'redhat'
 
     - role: tests
       expected_java_version: "{{ test_expected_java_version }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -25,22 +25,12 @@
   gather_facts: yes
   vars:
     debug: yes
-    test_redhat_java_version: '10.0.2'
-    test_debian_java_version: '10.0.2'
+    test_expected_java_version: '10.0.2'
 
   roles:
     - role: oracle-java
       when: ansible_os_family | lower == 'redhat'
 
     - role: tests
-      expected_java_version: "{{ test_redhat_java_version }}"
+      expected_java_version: "{{ test_expected_java_version }}"
       tags: [ test ]
-      when: ansible_os_family | lower == 'redhat'
-
-    - role: oracle-java
-      when: ansible_os_family | lower == 'debian'
-
-    - role: tests
-      expected_java_version: "{{ test_debian_java_version }}"
-      tags: [ test ]
-      when: ansible_os_family | lower == 'debian'

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -34,8 +34,7 @@ ansible-playbook \
     -e env=travis \
     --skip-tags=test \
     $@ \
-&& bash test_checkmode.sh \
-    --env travis \
 && bash test_idempotence.sh \
+    --env travis \
+&& bash test_checkmode.sh \
     --env travis
-


### PR DESCRIPTION
- added support for Java 11
- Java 10 is no longer supported; read more about this [here](https://www.linuxuprising.com/2018/04/install-oracle-java-10-jdk-10-in-debian.html)
- added `oracle_java_license_version` variable to support Java 11 installation
- updated Java 8 example: closes #98
- updated CentOS 7 Java 8 examples: closes #99
- minor cleanup on test playbook


thank you @d4rkd0s and @pulse-mind for reporting the example issues and contribution.
