### PR TITLE
Only start download, if there is a different version then installed

### DIFF
--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -12,4 +12,4 @@ oracle_java_rpm_url: 'http://download.oracle.com/otn-pub/java/jdk/11.0.1+13/90cf
 oracle_java_rpm_validate_certs: yes
 oracle_java_version: 11
 oracle_java_version_string: 11.0.1
-latest_jdk: false
+oracle_java_latest: false

--- a/defaults/redhat.yml
+++ b/defaults/redhat.yml
@@ -12,3 +12,4 @@ oracle_java_rpm_url: 'http://download.oracle.com/otn-pub/java/jdk/11.0.1+13/90cf
 oracle_java_rpm_validate_certs: yes
 oracle_java_version: 11
 oracle_java_version_string: 11.0.1
+latest_jdk: false

--- a/tasks/darwin/macosx.yml
+++ b/tasks/darwin/macosx.yml
@@ -7,7 +7,7 @@
 - name: download DMG file
   shell:
     "curl -L  -H 'Cookie:oraclelicense=accept-securebackup-cookie' -o {{ oracle_java_dir_source }}/{{ oracle_java_dmg_filename }} {{ oracle_java_dmg_url }}"
-  when: not oracle_java_task_dmg_check|skipped and not oracle_java_task_dmg_check.stat.exists
+  when: not oracle_java_task_dmg_check is skipped and not oracle_java_task_dmg_check.stat.exists
   args:
     creates: "{{ oracle_java_dir_source }}/{{ oracle_java_dmg_filename }}"
   tags:
@@ -36,4 +36,3 @@
 
 - name: in case there were changes, check host environment again
   include: ../check_environment.yml
-

--- a/tasks/darwin/macosx.yml
+++ b/tasks/darwin/macosx.yml
@@ -5,11 +5,17 @@
 #
 
 - name: download DMG file
-  shell:
-    "curl -L  -H 'Cookie:oraclelicense=accept-securebackup-cookie' -o {{ oracle_java_dir_source }}/{{ oracle_java_dmg_filename }} {{ oracle_java_dmg_url }}"
-  when: not oracle_java_task_dmg_check is skipped and not oracle_java_task_dmg_check.stat.exists
-  args:
-    creates: "{{ oracle_java_dir_source }}/{{ oracle_java_dmg_filename }}"
+  get_url:
+    headers:
+      Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F
+      oraclelicense: accept-securebackup-cookie
+    dest: "{{ oracle_java_dir_source }}/{{ oracle_java_dmg_filename }}"
+    url: "{{ oracle_java_dmg_url }}"
+    validate_certs: "{{ oracle_java_dmg_validate_certs }}"
+    timeout: "{{ oracle_java_download_timeout }}"
+    force: no
+  register: oracle_java_task_dmg_download
+  until: oracle_java_task_dmg_download is succeeded
   tags:
     - installation
 

--- a/tasks/find_latest.yml
+++ b/tasks/find_latest.yml
@@ -1,0 +1,56 @@
+---
+# tasks file to find latest JDK version
+- name: lookup available JDK downloads
+  uri:
+    url: "https://www.oracle.com/technetwork/java/javase/downloads/index.html"
+    return_content: yes
+    validate_certs: no
+  register: oracle_downloads
+
+- name: lookup URL for downloads
+  set_fact:
+    oracle_downloads_url: "{{ oracle_downloads.content | regex_search( regexp ) }}"
+  vars:
+    regexp: "\/technetwork\/java\/javase\/downloads\/jdk{{ oracle_java_version }}-downloads-.+.html"
+
+- name: lookup available JDK files
+  uri:
+    url: "https://www.oracle.com/{{ oracle_downloads_url }}"
+    return_content: yes
+    validate_certs: no
+  register: oracle_java_files
+
+- block:
+  - name: lookup JDK RPM url
+    set_fact:
+      oracle_java_rpm_url: "{{ oracle_java_files.content | regex_search( regexp ) }}"
+    vars:
+        regexp: "http[s]?:\/\/download.oracle.com\/otn-pub\/java\/jdk/{{ oracle_java_version }}u[0-9]+-[a-z0-9]+/[a-z0-9]+/jdk-{{ oracle_java_version }}u[0-9]+-linux-x64.rpm"
+  - name: lookup JDK RPM filename
+    set_fact:
+      oracle_java_rpm_filename: "{{ oracle_java_rpm_url | regex_search( regexp) }}"
+    vars:
+        regexp: "jdk-{{ oracle_java_version }}u[0-9]+-linux-x64.rpm"
+  - name: lookup java update string
+    set_fact:
+      oracle_java_update_string: "{{ oracle_java_rpm_filename | regex_replace( '^jdk-[0-9]+u(?P<u>[0-9]+)-linux-x64.rpm$', '\\g<u>' )}}"
+  - name: lookup java version string
+    set_fact:
+      oracle_java_version_string: "1.{{ oracle_java_version }}.0_{{ oracle_java_update_string }}"
+  when: oracle_java_version == 8
+
+- block:
+  - name: lookup JDK RPM url
+    set_fact:
+      oracle_java_rpm_url: "{{ oracle_java_files.content | regex_search( regexp ) }}"
+    vars:
+        regexp: "http[s]?:\/\/download.oracle.com\/otn-pub\/java\/jdk\/{{ oracle_java_version }}.[.0-9+]+/[a-z0-9]+/jdk-{{ oracle_java_version }}.[0-9.]+_linux-x64_bin.rpm"
+  - name: lookup JDK RPM filename
+    set_fact:
+      oracle_java_rpm_filename: "{{ oracle_java_rpm_url | regex_search( regexp) }}"
+    vars:
+        regexp: "jdk-{{ oracle_java_version }}.[0-9.]+_linux-x64_bin.rpm"
+  - name: lookup java version string
+    set_fact:
+      oracle_java_version_string: "{{ oracle_java_rpm_filename | regex_replace( '^jdk-(?P<v>[0-9.]+)_linux-x64_bin.rpm$', '\\g<v>' )}}"
+  when: oracle_java_version == 11

--- a/tasks/find_latest.yml
+++ b/tasks/find_latest.yml
@@ -11,7 +11,7 @@
   set_fact:
     oracle_downloads_url: "{{ oracle_downloads.content | regex_search( regexp ) }}"
   vars:
-    regexp: "\/technetwork\/java\/javase\/downloads\/jdk{{ oracle_java_version }}-downloads-.+.html"
+    regexp: '/technetwork/java/javase/downloads/jdk{{ oracle_java_version }}-downloads-.+.html'
 
 - name: lookup available JDK files
   uri:
@@ -25,7 +25,7 @@
     set_fact:
       oracle_java_rpm_url: "{{ oracle_java_files.content | regex_search( regexp ) }}"
     vars:
-        regexp: "http[s]?:\/\/download.oracle.com\/otn-pub\/java\/jdk/{{ oracle_java_version }}u[0-9]+-[a-z0-9]+/[a-z0-9]+/jdk-{{ oracle_java_version }}u[0-9]+-linux-x64.rpm"
+        regexp: 'http[s]?://download.oracle.com/otn-pub/java/jdk/{{ oracle_java_version }}u[0-9]+-[a-z0-9]+/[a-z0-9]+/jdk-{{ oracle_java_version }}u[0-9]+-linux-x64.rpm'
   - name: lookup JDK RPM filename
     set_fact:
       oracle_java_rpm_filename: "{{ oracle_java_rpm_url | regex_search( regexp) }}"
@@ -44,7 +44,7 @@
     set_fact:
       oracle_java_rpm_url: "{{ oracle_java_files.content | regex_search( regexp ) }}"
     vars:
-        regexp: "http[s]?:\/\/download.oracle.com\/otn-pub\/java\/jdk\/{{ oracle_java_version }}.[.0-9+]+/[a-z0-9]+/jdk-{{ oracle_java_version }}.[0-9.]+_linux-x64_bin.rpm"
+        regexp: 'http[s]?://download.oracle.com/otn-pub/java/jdk/{{ oracle_java_version }}.[.0-9+]+/[a-z0-9]+/jdk-{{ oracle_java_version }}.[0-9.]+_linux-x64_bin.rpm'
   - name: lookup JDK RPM filename
     set_fact:
       oracle_java_rpm_filename: "{{ oracle_java_rpm_url | regex_search( regexp) }}"

--- a/tasks/installation/redhat/main.yml
+++ b/tasks/installation/redhat/main.yml
@@ -13,31 +13,33 @@
     timeout={{ oracle_java_download_timeout }}
     force=no
   register: oracle_java_task_rpm_download
-  until: oracle_java_task_rpm_download|succeeded 
+  until: oracle_java_task_rpm_download is succeeded
   become: yes
 
 - name: install RPM
   yum:
     name="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
     state=present
-  when: not oracle_java_task_rpm_download|skipped
+  when: not oracle_java_task_rpm_download is skipped
   become: yes
 
 - name: set Java version as default
   alternatives:
-    name="{{ item.exe }}"
-    link="/usr/bin/{{ item.exe }}"
-    path="{{ item.path }}/{{ item.exe }}"
+    name="{{ java.exe }}"
+    link="/usr/bin/{{ java.exe }}"
+    path="{{ java.path }}/{{ java.exe }}"
   with_items:
     - { path: "{{ oracle_java_home }}/bin", exe: 'java' }
     - { path: "{{ oracle_java_home }}/bin", exe: 'keytool' }
     - { path: "{{ oracle_java_home }}/bin", exe: 'javac' }
     - { path: "{{ oracle_java_home }}/bin", exe: 'javadoc' }
+  loop_control:
+      loop_var: java
   become: yes
   when: (
           oracle_java_set_as_default and
           oracle_java_task_rpm_download is defined and
-          oracle_java_task_rpm_download|changed
+          oracle_java_task_rpm_download is changed
         ) or (
           oracle_java_set_as_default and
           oracle_java_installed is defined and

--- a/tasks/installation/redhat/main.yml
+++ b/tasks/installation/redhat/main.yml
@@ -7,8 +7,7 @@
 - name: download Java RPM
   get_url:
     headers:
-      Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F
-      oraclelicense: accept-securebackup-cookie
+      Cookie: "gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie"
     dest: "{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
     url: "{{ oracle_java_rpm_url }}"
     validate_certs: "{{ oracle_java_rpm_validate_certs }}"

--- a/tasks/installation/redhat/main.yml
+++ b/tasks/installation/redhat/main.yml
@@ -6,12 +6,14 @@
 
 - name: download Java RPM
   get_url:
-    headers='Cookie:gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie'
-    dest="{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
-    url="{{ oracle_java_rpm_url }}"
-    validate_certs="{{ oracle_java_rpm_validate_certs }}"
-    timeout={{ oracle_java_download_timeout }}
-    force=no
+    headers:
+      Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F
+      oraclelicense: accept-securebackup-cookie
+    dest: "{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"
+    url: "{{ oracle_java_rpm_url }}"
+    validate_certs: "{{ oracle_java_rpm_validate_certs }}"
+    timeout: "{{ oracle_java_download_timeout }}"
+    force: no
   register: oracle_java_task_rpm_download
   until: oracle_java_task_rpm_download is succeeded
   become: yes

--- a/tasks/installation/redhat/main.yml
+++ b/tasks/installation/redhat/main.yml
@@ -17,6 +17,7 @@
   register: oracle_java_task_rpm_download
   until: oracle_java_task_rpm_download is succeeded
   become: yes
+  when: oracle_java_version_installed is not defined or oracle_java_version_installed != oracle_java_version_string
 
 - name: install RPM
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: find latest JDK version
   include: find_latest.yml
-  when: oracle_java_latest
+  when: oracle_java_latest is defined and oracle_java_latest
 
 - include: debug.yml
   when: debug | default(false)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,10 @@
 - name: check host environment
   include: check_environment.yml
 
+- name: find latest JDK version
+  include: find_latest.yml
+  when: oracle_java_latest
+
 - include: debug.yml
   when: debug | default(false)
   tags: [ debug ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
     - "installation/{{ ansible_os_family | lower }}/{{ ansible_distribution | lower }}.yml"
     - "installation/{{ ansible_os_family | lower }}/main.yml"
   tags: [ installation ]
+  when: oracle_java_version_installed != oracle_java_version_string
 
 - name: check host environment
   include: check_environment.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,6 @@
     - "installation/{{ ansible_os_family | lower }}/{{ ansible_distribution | lower }}.yml"
     - "installation/{{ ansible_os_family | lower }}/main.yml"
   tags: [ installation ]
-  when: oracle_java_version_installed != oracle_java_version_string
 
 - name: check host environment
   include: check_environment.yml


### PR DESCRIPTION
I added to the main tasks: `when: oracle_java_version_installed != oracle_java_version_string` 
So the download/installation would only start if the installed version does not matches the intended version. 
I also had some Warnings  in Ansible, so I fixed them all. 

May I also suggest to add a task that find the lastest Update version of a JDK release? So this could then automatically fill in things like `oracle_java_rpm_filename`, `oracle_java_rpm_url`, `oracle_java_version_string` depending on which `oracle_java_version` is set.